### PR TITLE
feat: bump Angular to v17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26357,15 +26357,15 @@
     },
     "packages/ngx-fast-lib": {
       "name": "@push-based/ngx-fast-svg",
-      "version": "17.0.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
       },
       "devDependencies": {},
       "peerDependencies": {
-        "@angular/common": ">=17.0.0",
-        "@angular/core": ">=17.0.0",
+        "@angular/common": "^17.0.0",
+        "@angular/core": "^17.0.0",
         "rxjs": ">7.8.0"
       }
     }

--- a/packages/ngx-fast-lib/project.json
+++ b/packages/ngx-fast-lib/project.json
@@ -46,7 +46,7 @@
           "ngx-fast-lib:npm",
           "ngx-fast-lib:github"
         ],
-        "commitMessageFormat": "release(${projectName}): ${version}",
+        "commitMessageFormat": "release(${projectName}): {version}",
         "noVerify": true,
         "push": true
       }
@@ -54,8 +54,8 @@
     "github": {
       "executor": "@jscutlery/semver:github",
       "options": {
-        "tag": "${tag}",
-        "notes": "${notes}"
+        "tag": "{tag}",
+        "notes": "{notes}"
       }
     },
     "npm": {


### PR DESCRIPTION
BREAKING CHANGE: Minimum required `@angular/core` version is now `^17.0.0`